### PR TITLE
Fix error on startup with broken XML config

### DIFF
--- a/SevenConverter/Actions/Config.cs
+++ b/SevenConverter/Actions/Config.cs
@@ -26,10 +26,18 @@ namespace SevenConverter
             config_path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Files.Config_Folder);
             if (File.Exists(Path.Combine(config_path, Files.Config_Filename)))
             {
-                using (FileStream file = new FileStream(Path.Combine(config_path, Files.Config_Filename), FileMode.Open))
+                try
                 {
-                    XmlSerializer xml = new XmlSerializer(typeof(Settings));
-                    settings = xml.Deserialize(file) as Settings;
+                    using (FileStream file = new FileStream(Path.Combine(config_path, Files.Config_Filename), FileMode.Open))
+                    {
+                        XmlSerializer xml = new XmlSerializer(typeof(Settings));
+                        settings = xml.Deserialize(file) as Settings;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"Error loading config file: {ex.Message}. A new default config will be created.");
+                    settings = new Settings();
                 }
             }
             else


### PR DESCRIPTION
Fixes #22

Fix error on startup with broken XML config.

* Add a try-catch block around the deserialization code in the `LoadConfig` method to handle broken XML config files.
* Show an error message if an exception occurs during deserialization and create a new default `Settings` object.

